### PR TITLE
Add lightweight server and improve API integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,40 @@
 # BillionsMind
+
+Aplicação estática do BillionMind AI com conjunto de rotas backend leves para login, planos, histórico e integrações com OpenAI/Supabase.
+
+## Requisitos
+- Node.js 18 ou superior (usa `fetch` nativo, sem dependências externas).
+- Variáveis de ambiente configuradas para os serviços externos.
+
+### Variáveis de ambiente
+Crie um arquivo `.env` (ou exporte no shell) contendo:
+
+```
+PORT=3000
+OPENAI_API_KEY=coloque_sua_chave
+SUPABASE_URL=https://<sua-instancia>.supabase.co
+SUPABASE_ANON_KEY=chave_anon
+STRIPE_CHECKOUT_URL=https://link_da_sessao_de_checkout (opcional)
+```
+
+## Como rodar
+1. Inicie o servidor HTTP/rotas API:
+   ```bash
+   node server.js
+   ```
+2. Acesse http://localhost:3000 para abrir o app.
+3. As rotas em `/api` reutilizam as chaves configuradas acima. Caso as chaves não estejam definidas, as rotas retornarão mensagens de erro claras.
+
+## Rotas disponíveis
+- `POST /api/chat` – proxy para OpenAI Chat Completions.
+- `POST /api/image` – gera imagem via OpenAI (retorna data URI base64).
+- `POST /api/signup` – cria usuário no Supabase Auth e provisiona plano free.
+- `POST /api/login` – autentica usuário e retorna plano salvo.
+- `POST /api/saveMessage` – armazena mensagens no Supabase.
+- `POST /api/createPlan`, `GET /api/getPlan` – CRUD simplificado de planos.
+- `GET /api/getHistory` – histórico de mensagens.
+- `POST /api/updateConfig` – configurações do usuário.
+- `POST /api/checkout` – retorna URL de checkout (ou instrução se `STRIPE_CHECKOUT_URL` não estiver definida).
+
+## Observação
+O front-end principal está em `index.html` e continua funcional mesmo sem todas as integrações ativas; os endpoints acima completam o fluxo quando as credenciais reais forem informadas.

--- a/api/api/checkout.js
+++ b/api/api/checkout.js
@@ -1,0 +1,17 @@
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ error: "Método não permitido" });
+  }
+
+  const checkoutUrl = process.env.STRIPE_CHECKOUT_URL;
+
+  if (!checkoutUrl) {
+    return res.status(200).json({
+      url: null,
+      note:
+        "Defina STRIPE_CHECKOUT_URL no ambiente para redirecionar para o pagamento real.",
+    });
+  }
+
+  return res.status(200).json({ url: checkoutUrl });
+}

--- a/api/api/createPlan.js
+++ b/api/api/createPlan.js
@@ -1,24 +1,47 @@
-import { createClient } from '@supabase/supabase-js';
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_ANON_KEY
-);
+function missingConfig(res) {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    res.status(500).json({ error: "Configurações do Supabase ausentes no ambiente." });
+    return true;
+  }
+  return false;
+}
 
 export default async function handler(req, res) {
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Método não permitido" });
   }
 
-  const { user_id, titulo, conteudo } = req.body;
+  if (missingConfig(res)) return;
 
-  const { data, error } = await supabase
-    .from("planos")
-    .insert([{ user_id, titulo, conteudo }]);
+  try {
+    const { user_id, titulo, conteudo } = req.body || {};
+    if (!user_id || !titulo || !conteudo) {
+      return res.status(400).json({ error: "Campos obrigatórios não enviados." });
+    }
 
-  if (error) {
+    const response = await fetch(`${SUPABASE_URL}/rest/v1/planos`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        apikey: SUPABASE_ANON_KEY,
+        Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+        Prefer: "return=representation",
+      },
+      body: JSON.stringify([{ user_id, titulo, conteudo }]),
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(err || "Erro ao salvar plano");
+    }
+
+    const data = await response.json();
+    return res.status(200).json({ status: "plano_criado", data });
+  } catch (error) {
+    console.error(error);
     return res.status(400).json({ error: error.message });
   }
-
-  return res.status(200).json({ status: "plano_criado", data });
 }

--- a/api/api/getHistory.js
+++ b/api/api/getHistory.js
@@ -1,22 +1,40 @@
-import { createClient } from '@supabase/supabase-js';
-
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_ANON_KEY
-);
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
 
 export default async function handler(req, res) {
-  const { user_id } = req.query;
-
-  const { data, error } = await supabase
-    .from("historico")
-    .select("*")
-    .eq("user_id", user_id)
-    .order("criado_em", { ascending: false });
-
-  if (error) {
-    return res.status(400).json({ error: error.message });
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Método não permitido" });
   }
 
-  return res.status(200).json(data);
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    return res.status(500).json({ error: "Configurações do Supabase ausentes." });
+  }
+
+  const { user_id } = req.query || {};
+  if (!user_id) {
+    return res.status(400).json({ error: "user_id é obrigatório" });
+  }
+
+  try {
+    const response = await fetch(
+      `${SUPABASE_URL}/rest/v1/historico?user_id=eq.${user_id}&select=*&order=criado_em.desc`,
+      {
+        headers: {
+          apikey: SUPABASE_ANON_KEY,
+          Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(err || "Erro ao buscar histórico");
+    }
+
+    const data = await response.json();
+    return res.status(200).json(data);
+  } catch (error) {
+    console.error(error);
+    return res.status(400).json({ error: error.message });
+  }
 }

--- a/api/api/login.js
+++ b/api/api/login.js
@@ -1,36 +1,85 @@
-import { createClient } from "@supabase/supabase-js";
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
+
+function missingConfig(res) {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    res.status(500).json({ error: "Configurações do Supabase ausentes no ambiente." });
+    return true;
+  }
+  return false;
+}
+
+async function callSupabaseAuth(email, password) {
+  const response = await fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=password`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+    },
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(err || "Falha no login.");
+  }
+
+  return response.json();
+}
+
+async function fetchPlano(userId) {
+  const response = await fetch(
+    `${SUPABASE_URL}/rest/v1/usa_planos?id=eq.${userId}&select=*`,
+    {
+      headers: {
+        apikey: SUPABASE_ANON_KEY,
+        Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+      },
+    }
+  );
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(err || "Não foi possível recuperar o plano");
+  }
+
+  const data = await response.json();
+  return data?.[0] || null;
+}
 
 export default async function handler(req, res) {
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Método não permitido" });
   }
 
-  const supabase = createClient(
-    process.env.SUPABASE_URL,
-    process.env.SUPABASE_ANON_KEY
-  );
+  if (missingConfig(res)) return;
 
-  const { email, password } = req.body;
+  try {
+    const { email, password } = req.body || {};
+    if (!email || !password) {
+      return res.status(400).json({ error: "Email e senha são obrigatórios." });
+    }
 
-  const { data: authData, error: authError } = await supabase.auth.signInWithPassword({
-    email,
-    password,
-  });
+    const authData = await callSupabaseAuth(email, password);
+    const user = authData.user || authData?.user_metadata || authData;
 
-  if (authError) {
-    return res.status(400).json({ error: authError.message });
+    let plano = null;
+    if (user?.id) {
+      try {
+        plano = await fetchPlano(user.id);
+      } catch (error) {
+        console.warn("Falha ao carregar plano do usuário", error.message);
+      }
+    }
+
+    return res.status(200).json({
+      message: "Login bem-sucedido!",
+      user,
+      plano,
+    });
+  } catch (error) {
+    console.error(error);
+    return res.status(400).json({ error: error.message });
   }
-
-  // Buscar plano do usuário
-  const { data: planoData, error: planoError } = await supabase
-    .from("usa_planos")
-    .select("*")
-    .eq("id", authData.user.id)
-    .single();
-
-  return res.status(200).json({
-    message: "Login bem-sucedido!",
-    user: authData.user,
-    plano: planoData,
-  });
 }

--- a/api/api/signup.js
+++ b/api/api/signup.js
@@ -1,38 +1,73 @@
-import { createClient } from "@supabase/supabase-js";
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
+
+function missingConfig(res) {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    res.status(500).json({ error: "Configurações do Supabase ausentes no ambiente." });
+    return true;
+  }
+  return false;
+}
+
+async function createUser(email, password) {
+  const response = await fetch(`${SUPABASE_URL}/auth/v1/signup`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+    },
+    body: JSON.stringify({ email, password }),
+  });
+
+  if (!response.ok) {
+    const err = await response.text();
+    throw new Error(err || "Erro ao criar usuário");
+  }
+
+  return response.json();
+}
+
+async function createStarterPlan(userId, email) {
+  const response = await fetch(`${SUPABASE_URL}/rest/v1/usa_planos`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+      Prefer: "resolution=merge-duplicates",
+    },
+    body: JSON.stringify([{ id: userId, email, plano: "free", renovacao: null }]),
+  });
+
+  if (!response.ok) {
+    console.warn("Não foi possível salvar plano inicial", await response.text());
+  }
+}
 
 export default async function handler(req, res) {
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Método não permitido" });
   }
 
-  const supabase = createClient(
-    process.env.SUPABASE_URL,
-    process.env.SUPABASE_ANON_KEY
-  );
+  if (missingConfig(res)) return;
 
-  const { email, password } = req.body;
+  try {
+    const { email, password } = req.body || {};
+    if (!email || !password) {
+      return res.status(400).json({ error: "Email e senha são obrigatórios." });
+    }
 
-  // Criar conta no Supabase Auth
-  const { data: authData, error: authError } = await supabase.auth.signUp({
-    email,
-    password,
-  });
+    const authData = await createUser(email, password);
+    const userId = authData?.user?.id;
 
-  if (authError) {
-    return res.status(400).json({ error: authError.message });
+    if (userId) {
+      await createStarterPlan(userId, email);
+    }
+
+    return res.status(200).json({ message: "Conta criada com sucesso!", user: authData.user });
+  } catch (error) {
+    console.error(error);
+    return res.status(400).json({ error: error.message });
   }
-
-  const userId = authData.user.id;
-
-  // Criar plano inicial FREE
-  await supabase.from("usa_planos").insert([
-    {
-      id: userId,
-      email,
-      plano: "free",
-      renovacao: null,
-    },
-  ]);
-
-  return res.status(200).json({ message: "Conta criada com sucesso!", user: authData.user });
 }

--- a/api/api/updateConfig.js
+++ b/api/api/updateConfig.js
@@ -1,31 +1,48 @@
-import { createClient } from '@supabase/supabase-js';
-
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_ANON_KEY
-);
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
 
 export default async function handler(req, res) {
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Método não permitido" });
   }
 
-  const { user_id, meta_diaria, modo_dark, notificacoes } = req.body;
-
-  const { data, error } = await supabase
-    .from("config_usuario")
-    .upsert([
-      {
-        user_id,
-        meta_diaria,
-        modo_dark,
-        notificacoes
-      }
-    ]);
-
-  if (error) {
-    return res.status(400).json({ error: error.message });
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    return res.status(500).json({ error: "Configurações do Supabase ausentes." });
   }
 
-  return res.status(200).json({ status: "config_atualizada", data });
+  try {
+    const { user_id, meta_diaria, modo_dark, notificacoes } = req.body || {};
+    if (!user_id) {
+      return res.status(400).json({ error: "user_id é obrigatório" });
+    }
+
+    const response = await fetch(`${SUPABASE_URL}/rest/v1/config_usuario`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        apikey: SUPABASE_ANON_KEY,
+        Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+        Prefer: "resolution=merge-duplicates",
+      },
+      body: JSON.stringify([
+        {
+          user_id,
+          meta_diaria,
+          modo_dark,
+          notificacoes,
+        },
+      ]),
+    });
+
+    if (!response.ok) {
+      const err = await response.text();
+      throw new Error(err || "Erro ao atualizar configuração");
+    }
+
+    const data = await response.json();
+    return res.status(200).json({ status: "config_atualizada", data });
+  } catch (error) {
+    console.error(error);
+    return res.status(400).json({ error: error.message });
+  }
 }

--- a/api/chat.js
+++ b/api/chat.js
@@ -4,7 +4,13 @@ export default async function handler(req, res) {
   }
 
   try {
-    const { message } = req.body;
+    const { message } = req.body || {};
+
+    if (!process.env.OPENAI_API_KEY) {
+      return res
+        .status(500)
+        .json({ error: "OPENAI_API_KEY não configurada no ambiente." });
+    }
 
     if (!message || typeof message !== "string") {
       return res.status(400).json({ error: "Mensagem inválida" });
@@ -14,7 +20,7 @@ export default async function handler(req, res) {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "Authorization": `Bearer ${process.env.OPENAI_API_KEY}`
+        Authorization: `Bearer ${process.env.OPENAI_API_KEY}`,
       },
       body: JSON.stringify({
         model: "gpt-4o-mini",
@@ -23,16 +29,16 @@ export default async function handler(req, res) {
             role: "system",
             content:
               "Você é a BillionMind AI, um mentor de disciplina, dinheiro e lifestyle de alto desempenho. " +
-              "Responda sempre em português, de forma direta, prática e motivadora."
+              "Responda sempre em português, de forma direta, prática e motivadora.",
           },
           {
             role: "user",
-            content: message
-          }
+            content: message,
+          },
         ],
         temperature: 0.8,
-        max_tokens: 400
-      })
+        max_tokens: 400,
+      }),
     });
 
     if (!openaiRes.ok) {

--- a/api/saveMessage.js
+++ b/api/saveMessage.js
@@ -1,30 +1,53 @@
-import { createClient } from '@supabase/supabase-js';
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
 
-const supabase = createClient(
-  process.env.SUPABASE_URL,
-  process.env.SUPABASE_ANON_KEY
-);
+async function insertRow(table, payload) {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    throw new Error("SUPABASE_URL ou SUPABASE_ANON_KEY não configurados.");
+  }
+
+  const response = await fetch(`${SUPABASE_URL}/rest/v1/${table}`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      apikey: SUPABASE_ANON_KEY,
+      Authorization: `Bearer ${SUPABASE_ANON_KEY}`,
+      Prefer: "return=representation",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(text || "Erro ao salvar no Supabase.");
+  }
+
+  return response.json();
+}
 
 export default async function handler(req, res) {
   if (req.method !== "POST") {
     return res.status(405).json({ error: "Método não permitido" });
   }
 
-  const { user_id, mensagem, resposta } = req.body;
+  try {
+    const { user_id, mensagem, resposta } = req.body || {};
 
-  const { data, error } = await supabase
-    .from("historico")
-    .insert([
+    if (!user_id || !mensagem || !resposta) {
+      return res.status(400).json({ error: "Campos obrigatórios não enviados." });
+    }
+
+    const data = await insertRow("historico", [
       {
         user_id,
         mensagem_usuario: mensagem,
-        resposta_ai: resposta
-      }
+        resposta_ai: resposta,
+      },
     ]);
 
-  if (error) {
-    return res.status(400).json({ error: error.message });
+    return res.status(200).json({ status: "salvo", data });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ error: error.message });
   }
-
-  return res.status(200).json({ status: "salvo", data });
 }

--- a/index.html
+++ b/index.html
@@ -1183,6 +1183,7 @@
 
     function setStoredCv(v) {
       localStorage.setItem("bm_cv", String(v));
+      updateKpis();
     }
 
     function getCvLevel(cv) {
@@ -1218,6 +1219,7 @@
 
       profileCvLine.textContent = "Capital de Vida: " + cv + " (" + risco + ")";
       profileLevelLine.textContent = "Status: " + level + " · seu acesso aumenta com o seu CV.";
+      updateKpis();
     }
 
     updateCvUi();

--- a/index.html
+++ b/index.html
@@ -682,6 +682,69 @@
       color: var(--gold);
     }
 
+    /* AUTH / INTEGRAÇÃO */
+    .auth-card {
+      margin-top: 12px;
+      padding: 10px 12px;
+      border-radius: 14px;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      background: linear-gradient(145deg, rgba(8, 47, 73, 0.32), rgba(6, 9, 18, 0.88));
+      display: grid;
+      gap: 8px;
+    }
+
+    .auth-fields {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 8px;
+    }
+
+    .auth-fields input {
+      width: 100%;
+      border-radius: 10px;
+      border: 1px solid rgba(148, 163, 184, 0.55);
+      background: rgba(4, 7, 15, 0.95);
+      color: var(--text-main);
+      padding: 8px 10px;
+      font-size: 0.85rem;
+    }
+
+    .auth-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+    }
+
+    .status-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 9px;
+      border-radius: 12px;
+      background: rgba(16, 185, 129, 0.12);
+      color: var(--emerald-soft);
+      border: 1px solid rgba(16, 185, 129, 0.35);
+      font-size: 0.8rem;
+    }
+
+    .history-list {
+      display: grid;
+      gap: 6px;
+      font-size: 0.78rem;
+      color: var(--text-soft);
+      max-height: 240px;
+      overflow: auto;
+      border-top: 1px solid rgba(148, 163, 184, 0.25);
+      padding-top: 6px;
+    }
+
+    .history-item {
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      border-radius: 10px;
+      padding: 7px 8px;
+      background: rgba(5, 7, 15, 0.92);
+    }
+
     /* NAV INFERIOR */
     nav.bottom-nav {
       position: fixed;
@@ -1026,6 +1089,34 @@
             Se sua rota /api/checkout estiver configurada, este botão abrirá o pagamento oficial da Stripe.
           </p>
         </div>
+
+        <div class="auth-card">
+          <div>
+            <div class="bp-section-title" style="color: var(--text-soft);">Login real com Supabase</div>
+            <p class="forge-note" style="margin: 4px 0 6px;">
+              Crie sua conta ou faça login usando as rotas backend deste projeto. O status abaixo muda conforme a sessão.
+            </p>
+          </div>
+          <div class="auth-fields">
+            <input id="authEmail" type="email" placeholder="Seu e-mail" />
+            <input id="authPassword" type="password" placeholder="Senha (mín. 6 caracteres)" />
+          </div>
+          <div class="auth-actions">
+            <button class="btn-primary" id="btnSignup">Criar conta</button>
+            <button class="btn-secondary" id="btnLogin">Entrar</button>
+            <button class="btn-small" id="btnLogout">Sair</button>
+            <div class="status-chip" id="authStatus">Offline · simulando</div>
+          </div>
+          <div>
+            <div class="bp-section-title" style="color: var(--text-soft);">Histórico (Supabase)</div>
+            <p class="forge-note" style="margin-bottom:6px;">Entrou? Busque seu histórico salvo no Supabase.</p>
+            <div class="auth-actions">
+              <button class="btn-small" id="btnLoadHistory">🔄 Atualizar histórico</button>
+              <button class="btn-small" id="btnSyncPlan">💾 Enviar plano do dia</button>
+            </div>
+            <div class="history-list" id="historyList"></div>
+          </div>
+        </div>
       </section>
     </main>
   </div>
@@ -1175,6 +1266,7 @@
       setCompletedToday();
       updateCvUi();
       updateForgeState();
+      syncPlanToSupabase(false);
       alert("Protocolo concluído. Seu CV subiu para " + newCv + ".");
     });
 
@@ -1259,6 +1351,18 @@
     const btnSimularLogin = document.getElementById("btnSimularLogin");
     const btnSimularElite = document.getElementById("btnSimularElite");
     const btnSimularVip = document.getElementById("btnSimularVip");
+    const authEmail = document.getElementById("authEmail");
+    const authPassword = document.getElementById("authPassword");
+    const authStatus = document.getElementById("authStatus");
+    const btnSignup = document.getElementById("btnSignup");
+    const btnLogin = document.getElementById("btnLogin");
+    const btnLogout = document.getElementById("btnLogout");
+    const btnLoadHistory = document.getElementById("btnLoadHistory");
+    const btnSyncPlan = document.getElementById("btnSyncPlan");
+    const historyList = document.getElementById("historyList");
+
+    let currentUser = null;
+    let currentPlan = null;
 
     btnSimularLogin.addEventListener("click", () => {
       profileEmail.textContent = "brunobrandao179@gmail.com";
@@ -1276,6 +1380,187 @@
       profilePlanChip.style.borderColor = "#facc6b";
       badgeCv.style.borderColor = "rgba(250, 204, 107, 0.9)";
     });
+
+    function setStatus(text, success = false) {
+      authStatus.textContent = text;
+      authStatus.style.color = success ? "var(--emerald-soft)" : "var(--gold)";
+      authStatus.style.borderColor = success
+        ? "rgba(16, 185, 129, 0.35)"
+        : "rgba(250, 204, 107, 0.35)";
+      authStatus.style.background = success
+        ? "rgba(16, 185, 129, 0.12)"
+        : "rgba(250, 204, 107, 0.08)";
+    }
+
+    function persistUser(user, plan) {
+      localStorage.setItem(
+        "bm_user",
+        JSON.stringify({ id: user?.id, email: user?.email, plan: plan || null })
+      );
+    }
+
+    function hydrateUser() {
+      const raw = localStorage.getItem("bm_user");
+      if (!raw) return;
+      try {
+        const data = JSON.parse(raw);
+        currentUser = { id: data.id, email: data.email };
+        currentPlan = data.plan;
+        renderAuthUi();
+      } catch (e) {
+        console.warn("Falha ao carregar sessão local", e);
+      }
+    }
+
+    function renderAuthUi() {
+      if (currentUser?.email) {
+        profileEmail.textContent = currentUser.email;
+        profilePlanChip.textContent =
+          "Plano atual: " + (currentPlan?.plano || "Visionário (Supabase)");
+        setStatus("Online · " + currentUser.email, true);
+      } else {
+        profileEmail.textContent = "email@exemplo.com";
+        profilePlanChip.textContent = "Plano atual: Visionário (Gratuito)";
+        setStatus("Offline · simulando");
+      }
+    }
+
+    async function postJson(url, body) {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body || {}),
+      });
+
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.error || res.statusText);
+      }
+      return data;
+    }
+
+    async function getJson(url) {
+      const res = await fetch(url);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.error || res.statusText);
+      }
+      return data;
+    }
+
+    async function handleSignup() {
+      try {
+        if (!authEmail.value || !authPassword.value) {
+          return setStatus("Preencha e-mail e senha para criar a conta.");
+        }
+        const data = await postJson("/api/signup", {
+          email: authEmail.value,
+          password: authPassword.value,
+        });
+        setStatus("Conta criada! Faça login para carregar seus dados.", true);
+        console.info("Signup", data);
+      } catch (error) {
+        console.error(error);
+        setStatus("Falha ao criar conta: " + error.message);
+      }
+    }
+
+    async function handleLogin() {
+      try {
+        if (!authEmail.value || !authPassword.value) {
+          return setStatus("Preencha e-mail e senha para entrar.");
+        }
+        const data = await postJson("/api/login", {
+          email: authEmail.value,
+          password: authPassword.value,
+        });
+        currentUser = data.user || data?.user_metadata || { email: authEmail.value };
+        currentPlan = data.plano || null;
+        persistUser(currentUser, currentPlan);
+        renderAuthUi();
+        await loadHistory();
+      } catch (error) {
+        console.error(error);
+        setStatus("Falha no login: " + error.message);
+      }
+    }
+
+    function handleLogout() {
+      currentUser = null;
+      currentPlan = null;
+      localStorage.removeItem("bm_user");
+      historyList.innerHTML = "";
+      renderAuthUi();
+    }
+
+    async function loadHistory() {
+      if (!currentUser?.id) {
+        historyList.innerHTML =
+          '<div class="history-item">Entre para carregar seu histórico salvo.</div>';
+        return;
+      }
+
+      try {
+        const data = await getJson(`/api/getHistory?user_id=${encodeURIComponent(currentUser.id)}`);
+        if (!data.length) {
+          historyList.innerHTML =
+            '<div class="history-item">Nenhum histórico encontrado para este usuário.</div>';
+          return;
+        }
+
+        historyList.innerHTML = data
+          .map(
+            (item) => `
+              <div class="history-item">
+                <strong>${new Date(item.criado_em || item.created_at).toLocaleString()}</strong><br />
+                <div><em>Mensagem:</em> ${item.mensagem_usuario || item.mensagem}</div>
+                <div><em>Resposta:</em> ${item.resposta_ai || item.resposta || "(sem resposta)"}</div>
+              </div>
+            `
+          )
+          .join("");
+      } catch (error) {
+        console.error(error);
+        historyList.innerHTML =
+          '<div class="history-item">Erro ao carregar histórico: ' + error.message + "</div>";
+      }
+    }
+
+    async function syncPlanToSupabase(showToast = true) {
+      if (!currentUser?.id) {
+        if (showToast) alert("Faça login para enviar seu plano do dia.");
+        return;
+      }
+
+      const task = forgeTask.value.trim();
+      const t = forgeTime.value.trim();
+      const q = forgeQuality.value.trim();
+      if (!task || !t || !q) {
+        if (showToast) alert("Preencha a ação, tempo e qualidade para salvar no Supabase.");
+        return;
+      }
+
+      try {
+        const payload = {
+          user_id: currentUser.id,
+          titulo: `Protocolo ${new Date().toISOString().slice(0, 10)}`,
+          conteudo: `${task} | Tempo: ${t} | Qualidade: ${q}`,
+        };
+        await postJson("/api/createPlan", payload);
+        setStatus("Plano sincronizado no Supabase!", true);
+      } catch (error) {
+        console.error(error);
+        setStatus("Falha ao sincronizar plano: " + error.message);
+      }
+    }
+
+    btnSignup.addEventListener("click", handleSignup);
+    btnLogin.addEventListener("click", handleLogin);
+    btnLogout.addEventListener("click", handleLogout);
+    btnLoadHistory.addEventListener("click", loadHistory);
+    btnSyncPlan.addEventListener("click", () => syncPlanToSupabase(true));
+    hydrateUser();
+    renderAuthUi();
 
     // -------- Stripe (se /api/checkout existir) --------
     const btnAssinarPro = document.getElementById("btnAssinarPro");

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "billionsmind",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "BillionMind AI web experience with API helpers",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "node server.js"
+  },
+  "dependencies": {
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,122 @@
+import http from "http";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import chatHandler from "./api/chat.js";
+import saveMessageHandler from "./api/saveMessage.js";
+import createPlanHandler from "./api/api/createPlan.js";
+import getHistoryHandler from "./api/api/getHistory.js";
+import getPlanHandler from "./api/api/getPlan.js";
+import imageHandler from "./api/api/image.js";
+import loginHandler from "./api/api/login.js";
+import signupHandler from "./api/api/signup.js";
+import updateConfigHandler from "./api/api/updateConfig.js";
+import checkoutHandler from "./api/api/checkout.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const PORT = process.env.PORT || 3000;
+
+const routes = {
+  "/api/chat": chatHandler,
+  "/api/saveMessage": saveMessageHandler,
+  "/api/createPlan": createPlanHandler,
+  "/api/getHistory": getHistoryHandler,
+  "/api/getPlan": getPlanHandler,
+  "/api/image": imageHandler,
+  "/api/login": loginHandler,
+  "/api/signup": signupHandler,
+  "/api/updateConfig": updateConfigHandler,
+  "/api/checkout": checkoutHandler,
+};
+
+function decorateResponse(res) {
+  res.status = (code) => {
+    res.statusCode = code;
+    return res;
+  };
+  res.json = (payload) => {
+    if (!res.headersSent) {
+      res.writeHead(res.statusCode || 200, { "Content-Type": "application/json" });
+    }
+    res.end(JSON.stringify(payload));
+  };
+  res.send = (payload) => {
+    if (typeof payload === "object") {
+      return res.json(payload);
+    }
+    if (!res.headersSent) {
+      res.writeHead(res.statusCode || 200, { "Content-Type": "text/plain" });
+    }
+    res.end(payload);
+  };
+}
+
+function serveStatic(res, filePath) {
+  const resolvedPath = path.join(__dirname, filePath);
+  fs.readFile(resolvedPath, (err, data) => {
+    if (err) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Arquivo não encontrado" }));
+      return;
+    }
+    const contentType = filePath.endsWith(".html") ? "text/html" : "text/plain";
+    res.writeHead(200, { "Content-Type": contentType });
+    res.end(data);
+  });
+}
+
+function attachQuery(req, parsedUrl) {
+  req.query = Object.fromEntries(parsedUrl.searchParams.entries());
+}
+
+async function attachBody(req) {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    req.on("data", (chunk) => {
+      data += chunk;
+    });
+    req.on("end", () => {
+      if (!data) {
+        req.body = {};
+        return resolve();
+      }
+      try {
+        req.body = JSON.parse(data);
+        resolve();
+      } catch (err) {
+        reject(new Error("Falha ao fazer parse do corpo JSON."));
+      }
+    });
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  const parsedUrl = new URL(req.url, `http://${req.headers.host}`);
+  const pathname = parsedUrl.pathname;
+  decorateResponse(res);
+
+  if (routes[pathname]) {
+    try {
+      attachQuery(req, parsedUrl);
+      if (req.method !== "GET") {
+        await attachBody(req);
+      }
+      await routes[pathname](req, res);
+    } catch (error) {
+      console.error("Erro inesperado na rota", pathname, error);
+      res.status(500).json({ error: error.message || "Erro interno" });
+    }
+    return;
+  }
+
+  if (pathname === "/" || pathname === "/index.html") {
+    return serveStatic(res, "index.html");
+  }
+
+  res.status(404).json({ error: "Rota não encontrada" });
+});
+
+server.listen(PORT, () => {
+  console.log(`Servidor iniciado em http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a dependency-free Node server to serve the SPA and route API requests
- refactor Supabase/OpenAI handlers to use native fetch with clearer validation and errors
- document environment setup, available API routes, and checkout fallback behavior

## Testing
- node server.js (manual run)
- curl -X POST http://localhost:3000/api/checkout

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69272c6d0d14832dae8eba4661bd0381)